### PR TITLE
Update qubic-ts-library dependency version to 1.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "qubic-helper-utils",
+  "name": "ts-library-wrapper",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "dependencies": {
-        "@qubic-lib/qubic-ts-library": "^0.1.2",
+        "@qubic-lib/qubic-ts-library": "^0.1.5",
         "@qubic-lib/qubic-ts-vault-library": "^1.0.2",
         "bignumber.js": "^4.0.4",
         "functioneer": "^1.0.4",
@@ -1092,9 +1092,10 @@
       }
     },
     "node_modules/@qubic-lib/qubic-ts-library": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@qubic-lib/qubic-ts-library/-/qubic-ts-library-0.1.2.tgz",
-      "integrity": "sha512-AUEF9ooEnJgfG64iV2IbdmraTT729orCVlLPNupoOBUXh7FG1T7V1/yu7jobZwG3qUFLWIn8us9HGNGSNH12Mw==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@qubic-lib/qubic-ts-library/-/qubic-ts-library-0.1.5.tgz",
+      "integrity": "sha512-NK4LqlGRSHh9PH1MblmFEFPY9c7fMuHy678cuuPEXCAyoUlOpGAJdrsknJWTNXs8nJ4wSMQY8Xwlbi4kjRcMTQ==",
+      "license": "Qubic's Anti Military License",
       "dependencies": {
         "bignumber.js": "^9.1.2",
         "net": "^1.0.2"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "vm-browserify": "^1.1.2"
   },
   "dependencies": {
-    "@qubic-lib/qubic-ts-library": "^0.1.2",
+    "@qubic-lib/qubic-ts-library": "^0.1.5",
     "@qubic-lib/qubic-ts-vault-library": "^1.0.2",
     "bignumber.js": "^4.0.4",
     "functioneer": "^1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -625,10 +625,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@qubic-lib/qubic-ts-library@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.npmjs.org/@qubic-lib/qubic-ts-library/-/qubic-ts-library-0.1.2.tgz"
-  integrity sha512-AUEF9ooEnJgfG64iV2IbdmraTT729orCVlLPNupoOBUXh7FG1T7V1/yu7jobZwG3qUFLWIn8us9HGNGSNH12Mw==
+"@qubic-lib/qubic-ts-library@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.npmjs.org/@qubic-lib/qubic-ts-library/-/qubic-ts-library-0.1.5.tgz"
+  integrity sha512-NK4LqlGRSHh9PH1MblmFEFPY9c7fMuHy678cuuPEXCAyoUlOpGAJdrsknJWTNXs8nJ4wSMQY8Xwlbi4kjRcMTQ==
   dependencies:
     bignumber.js "^9.1.2"
     net "^1.0.2"
@@ -1372,6 +1372,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+fsevents@^2.3.2:
+  version "2.3.3"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
The new version contains an important update for the asset transfer fee that was lowered from 1M to 100 QUBIC.